### PR TITLE
feat: add audit-svc worm storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 .next/
 out/
 dist/
+dist-tests/
 build/
 .turbo/
 .vercel/

--- a/app/api/audit/[...key]/route.ts
+++ b/app/api/audit/[...key]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createAuditServiceFromEnv } from '../_lib/service';
+import { RetentionViolationError, ValidationError } from '../_lib/errors';
+
+function authorize(request: NextRequest, token: string | undefined, scope: string) {
+  if (!token) {
+    return NextResponse.json(
+      { error: 'authorization_not_configured', detail: `${scope} token is not configured` },
+      { status: 500 },
+    );
+  }
+  const header = request.headers.get('authorization');
+  if (!header || !header.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'unauthorized', detail: `${scope} token missing` }, { status: 401 });
+  }
+  const provided = header.slice('Bearer '.length).trim();
+  if (provided !== token) {
+    return NextResponse.json({ error: 'unauthorized', detail: `${scope} token invalid` }, { status: 401 });
+  }
+  return null;
+}
+
+function extractKey(params: { key?: string[] }): string | null {
+  if (!params.key || params.key.length === 0) {
+    return null;
+  }
+  return params.key.join('/');
+}
+
+export async function GET(request: NextRequest, context: { params: { key?: string[] } }) {
+  const auth = authorize(request, process.env.AUDIT_READ_TOKEN, 'read');
+  if (auth) return auth;
+  const key = extractKey(context.params);
+  if (!key) {
+    return NextResponse.json({ error: 'invalid_request', detail: 'key missing' }, { status: 400 });
+  }
+  const service = createAuditServiceFromEnv();
+  try {
+    const record = await service.get(key);
+    if (!record) {
+      return NextResponse.json({ error: 'not_found' }, { status: 404 });
+    }
+    return NextResponse.json(record);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: 'invalid_request', detail: error.message }, { status: error.status ?? 400 });
+    }
+    console.error('audit get error', error);
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest, context: { params: { key?: string[] } }) {
+  const auth = authorize(request, process.env.AUDIT_WRITE_TOKEN, 'write');
+  if (auth) return auth;
+  const key = extractKey(context.params);
+  if (!key) {
+    return NextResponse.json({ error: 'invalid_request', detail: 'key missing' }, { status: 400 });
+  }
+  const service = createAuditServiceFromEnv();
+  try {
+    await service.delete(key);
+    return NextResponse.json({ deleted: true });
+  } catch (error) {
+    if (error instanceof RetentionViolationError) {
+      return NextResponse.json(
+        { error: 'retention_active', detail: 'Object is locked by retention policy' },
+        { status: 409 },
+      );
+    }
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: 'invalid_request', detail: error.message }, { status: error.status ?? 400 });
+    }
+    console.error('audit delete error', error);
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+}

--- a/app/api/audit/_lib/errors.ts
+++ b/app/api/audit/_lib/errors.ts
@@ -1,0 +1,29 @@
+export class ValidationError extends Error {
+  status: number;
+  constructor(message: string, status = 400) {
+    super(message);
+    this.status = status;
+    this.name = 'ValidationError';
+  }
+}
+
+export class ChainError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ChainError';
+  }
+}
+
+export class RetentionViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RetentionViolationError';
+  }
+}
+
+export class ConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConflictError';
+  }
+}

--- a/app/api/audit/_lib/hash.ts
+++ b/app/api/audit/_lib/hash.ts
@@ -1,0 +1,38 @@
+import crypto from 'node:crypto';
+import { AuditLogInput, AuditLogStored } from './types';
+
+function canonicalStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    const items = value.map((item) => canonicalStringify(item));
+    return `[${items.join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([key, val]) => `${JSON.stringify(key)}:${canonicalStringify(val)}`);
+  return `{${entries.join(',')}}`;
+}
+
+export function canonicalEntryPayload(entry: AuditLogInput): string {
+  const clone: Record<string, unknown> = { ...entry };
+  delete clone.sig;
+  return canonicalStringify(clone);
+}
+
+export function hashEntry(entry: AuditLogInput): string {
+  const canonical = canonicalEntryPayload(entry);
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+export function computeHmac(prevHash: string | null, currentHash: string, secret: string): string {
+  const material = `${prevHash ?? ''}:${currentHash}`;
+  return crypto.createHmac('sha256', secret).update(material).digest('hex');
+}
+
+export function withoutSignature(entry: AuditLogStored): AuditLogInput {
+  const { sig: _sig, ...rest } = entry;
+  return rest;
+}

--- a/app/api/audit/_lib/service.ts
+++ b/app/api/audit/_lib/service.ts
@@ -1,0 +1,301 @@
+import crypto from 'node:crypto';
+import { RetentionViolationError, ValidationError } from './errors';
+import {
+  AppendResult,
+  AuditLogInput,
+  AuditLogStored,
+  AuditRecord,
+  AuditServiceConfig,
+  AuditStore,
+  ChainDiff,
+  ListOptions,
+  VerifyRange,
+  VerifyResult,
+} from './types';
+import { computeHmac, hashEntry, withoutSignature } from './hash';
+import { InMemoryAuditStore, R2AuditStore, R2AuditStoreConfig } from './stores';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function assertSafeCopy(entry: AuditLogInput) {
+  if (!entry.safe_copy) {
+    throw new ValidationError('safe_copy is required');
+  }
+  const sc = entry.safe_copy;
+  if (!sc.bucket || !sc.key || !sc.etag || !sc.checksum) {
+    throw new ValidationError('safe_copy must include bucket, key, etag, and checksum');
+  }
+  if (!sc.checksum.algorithm || !sc.checksum.value) {
+    throw new ValidationError('safe_copy.checksum must include algorithm and value');
+  }
+  const allowedAlgorithms = ['sha256', 'crc32c', 'crc64nvme', 'sha1'];
+  if (!allowedAlgorithms.includes(sc.checksum.algorithm)) {
+    throw new ValidationError(`Unsupported checksum algorithm: ${sc.checksum.algorithm}`);
+  }
+}
+
+function ensureIso8601(value: string, field: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new ValidationError(`${field} must be an ISO8601 timestamp`);
+  }
+  return date.toISOString();
+}
+
+function cloneInput(input: AuditLogInput): AuditLogInput {
+  return JSON.parse(JSON.stringify(input));
+}
+
+export class AuditService {
+  constructor(private store: AuditStore, private config: AuditServiceConfig) {}
+
+  private async getTail(): Promise<AuditRecord | null> {
+    let cursor: string | undefined;
+    let latest: AuditRecord | null = null;
+    do {
+      const { items, isTruncated, cursor: nextCursor } = await this.store.list({ cursor, limit: 100 });
+      if (items.length > 0) {
+        latest = items[items.length - 1];
+      }
+      if (!isTruncated) {
+        break;
+      }
+      cursor = nextCursor;
+      if (!cursor) {
+        break;
+      }
+    } while (cursor);
+    return latest;
+  }
+
+  private generateKey(tsIso: string): string {
+    const ts = new Date(tsIso);
+    const datePart = ts.toISOString().slice(0, 10).replace(/-/g, '/');
+    const timePart = ts.toISOString().slice(11, 23).replace(/[:.]/g, '');
+    const random = crypto.randomUUID();
+    return `${datePart}/${timePart}_${random}.json`;
+  }
+
+  private normalizeInput(input: AuditLogInput): AuditLogInput {
+    const clone = cloneInput(input);
+    clone.ts_iso = ensureIso8601(clone.ts_iso, 'ts_iso');
+    assertSafeCopy(clone);
+    if (clone.safe_copy.expires_at) {
+      clone.safe_copy.expires_at = ensureIso8601(clone.safe_copy.expires_at, 'safe_copy.expires_at');
+    }
+    if (clone.agent_version && clone.agent_version.length === 0) {
+      throw new ValidationError('agent_version cannot be empty when provided');
+    }
+    clone.version = 1;
+    return clone;
+  }
+
+  async append(input: AuditLogInput): Promise<AppendResult> {
+    const normalized = this.normalizeInput(input);
+    const retentionDays = this.config.retentionDays;
+    const retentionUntil = new Date(new Date(normalized.ts_iso).getTime() + retentionDays * DAY_MS);
+    const retentionIso = retentionUntil.toISOString();
+    const legalHold = normalized.worm?.legal_hold ?? this.config.legalHoldDefault ?? false;
+    const requestedRetention = normalized.worm?.retention_until;
+    const wormRetention = requestedRetention
+      ? ensureIso8601(requestedRetention, 'worm.retention_until')
+      : retentionIso;
+    normalized.worm = {
+      retention_until: wormRetention,
+      legal_hold: legalHold,
+    };
+    const prev = await this.getTail();
+    const prevHash = prev ? hashEntry(withoutSignature(prev.entry)) : null;
+    const currentHash = hashEntry(normalized);
+    const hmac = computeHmac(prevHash, currentHash, this.config.chainSecret);
+    const stored: AuditLogStored = {
+      ...normalized,
+      sig: {
+        prev_hash: prevHash,
+        hmac,
+      },
+      version: 1,
+    };
+    const key = this.generateKey(normalized.ts_iso);
+    const record: AuditRecord = {
+      key,
+      entry: stored,
+      retention_until: wormRetention,
+      legal_hold: legalHold,
+      created_at: new Date().toISOString(),
+    };
+    await this.store.append(record);
+    return {
+      key,
+      retention_until: record.retention_until,
+      entry: stored,
+    };
+  }
+
+  async get(key: string): Promise<AuditRecord | null> {
+    return this.store.get(key);
+  }
+
+  async list(options?: ListOptions) {
+    return this.store.list(options);
+  }
+
+  async verify(range: VerifyRange = {}): Promise<VerifyResult> {
+    const results: ChainDiff[] = [];
+    let checked = 0;
+    let cursor: string | undefined;
+    let startKey = range.start_key;
+    let endKey: string | undefined;
+    let firstKey: string | undefined;
+
+    const prevEntry = startKey ? await this.findPrevious(startKey) : null;
+    let expectedPrevHash = prevEntry ? hashEntry(withoutSignature(prevEntry.entry)) : null;
+
+    do {
+      const { items, isTruncated, cursor: nextCursor } = await this.store.list({
+        start_key: startKey,
+        cursor,
+        limit: range.limit,
+        end_key: range.end_key,
+      });
+      if (items.length === 0) {
+        break;
+      }
+      for (const record of items) {
+        const contentHash = hashEntry(withoutSignature(record.entry));
+        if (!firstKey) {
+          firstKey = record.key;
+        }
+        if (record.entry.sig.prev_hash !== expectedPrevHash) {
+          results.push({
+            key: record.key,
+            reason: 'missing-prev',
+            expected: expectedPrevHash,
+            actual: record.entry.sig.prev_hash,
+          });
+        }
+        const computedHmac = computeHmac(record.entry.sig.prev_hash, contentHash, this.config.chainSecret);
+        if (computedHmac !== record.entry.sig.hmac) {
+          results.push({
+            key: record.key,
+            reason: 'hmac-mismatch',
+            expected: computedHmac,
+            actual: record.entry.sig.hmac,
+          });
+        }
+        expectedPrevHash = contentHash;
+        checked += 1;
+        endKey = record.key;
+        if (range.end_key && record.key === range.end_key) {
+          return {
+            valid: results.length === 0,
+            checked,
+            range_start: range.start_key ?? firstKey,
+            range_end: endKey,
+            diffs: results,
+          };
+        }
+      }
+      if (!isTruncated) {
+        break;
+      }
+      cursor = nextCursor;
+      startKey = undefined;
+      if (!cursor) {
+        break;
+      }
+    } while (true);
+
+    return {
+      valid: results.length === 0,
+      checked,
+      range_start: range.start_key ?? firstKey,
+      range_end: endKey,
+      diffs: results,
+    };
+  }
+
+  private async findPrevious(key: string): Promise<AuditRecord | null> {
+    const { items } = await this.store.list({ end_key: key, limit: 1000 });
+    if (items.length === 0) {
+      return null;
+    }
+    return items[items.length - 1];
+  }
+
+  async delete(key: string): Promise<void> {
+    try {
+      await this.store.delete(key);
+    } catch (error) {
+      if (error instanceof RetentionViolationError) {
+        throw error;
+      }
+      throw error;
+    }
+  }
+}
+
+export interface EnvConfig {
+  AUDIT_CHAIN_SECRET?: string;
+  AUDIT_RETENTION_DAYS?: string;
+  AUDIT_LEGAL_HOLD_DEFAULT?: string;
+  AUDIT_R2_ACCOUNT_ID?: string;
+  AUDIT_R2_ACCESS_KEY_ID?: string;
+  AUDIT_R2_SECRET_ACCESS_KEY?: string;
+  AUDIT_R2_BUCKET?: string;
+  AUDIT_R2_PREFIX?: string;
+  AUDIT_STORE?: 'memory' | 'r2';
+}
+
+export function createAuditServiceFromEnv(env?: EnvConfig): AuditService {
+  const configuration = env ?? (process.env as unknown as EnvConfig);
+  const secret = configuration.AUDIT_CHAIN_SECRET;
+  if (!secret) {
+    throw new ValidationError('AUDIT_CHAIN_SECRET must be configured', 500);
+  }
+  const retentionDays = configuration.AUDIT_RETENTION_DAYS ? Number(configuration.AUDIT_RETENTION_DAYS) : 90;
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) {
+    throw new ValidationError('AUDIT_RETENTION_DAYS must be a positive integer', 500);
+  }
+  const config: AuditServiceConfig = {
+    retentionDays,
+    chainSecret: secret,
+    legalHoldDefault: configuration.AUDIT_LEGAL_HOLD_DEFAULT === 'true',
+  };
+  if (configuration.AUDIT_STORE === 'memory') {
+    const globalAny = globalThis as typeof globalThis & { __auditMemoryStore?: InMemoryAuditStore };
+    if (!globalAny.__auditMemoryStore) {
+      globalAny.__auditMemoryStore = new InMemoryAuditStore();
+    }
+    return new AuditService(globalAny.__auditMemoryStore, config);
+  }
+  const accountId = configuration.AUDIT_R2_ACCOUNT_ID;
+  const accessKeyId = configuration.AUDIT_R2_ACCESS_KEY_ID;
+  const secretAccessKey = configuration.AUDIT_R2_SECRET_ACCESS_KEY;
+  const bucket = configuration.AUDIT_R2_BUCKET;
+  if (!accountId || !accessKeyId || !secretAccessKey || !bucket) {
+    throw new ValidationError('R2 credentials are not fully configured', 500);
+  }
+  const storeConfig: R2AuditStoreConfig = {
+    accountId,
+    accessKeyId,
+    secretAccessKey,
+    bucket,
+    prefix: configuration.AUDIT_R2_PREFIX,
+  };
+  return new AuditService(new R2AuditStore(storeConfig), config);
+}
+
+export function createInMemoryAuditService(config: Partial<AuditServiceConfig> & { chainSecret: string }): AuditService {
+  const serviceConfig: AuditServiceConfig = {
+    retentionDays: config.retentionDays ?? 90,
+    chainSecret: config.chainSecret,
+    legalHoldDefault: config.legalHoldDefault ?? false,
+  };
+  return new AuditService(new InMemoryAuditStore(), serviceConfig);
+}
+
+export function resetInMemoryAuditStore(): void {
+  const globalAny = globalThis as typeof globalThis & { __auditMemoryStore?: InMemoryAuditStore };
+  globalAny.__auditMemoryStore?.reset();
+}

--- a/app/api/audit/_lib/stores.ts
+++ b/app/api/audit/_lib/stores.ts
@@ -1,0 +1,324 @@
+import crypto from 'node:crypto';
+import { ConflictError, RetentionViolationError } from './errors';
+import {
+  AuditRecord,
+  AuditStore,
+  AuditStoreListResult,
+  ListOptions,
+} from './types';
+
+function compareKeys(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+export class InMemoryAuditStore implements AuditStore {
+  private items = new Map<string, AuditRecord>();
+
+  async append(record: AuditRecord): Promise<void> {
+    if (this.items.has(record.key)) {
+      throw new ConflictError(`Object ${record.key} already exists`);
+    }
+    this.items.set(record.key, record);
+  }
+
+  async get(key: string): Promise<AuditRecord | null> {
+    return this.items.get(key) ?? null;
+  }
+
+  async list(options?: ListOptions): Promise<AuditStoreListResult> {
+    const allKeys = Array.from(this.items.keys()).sort(compareKeys);
+    const { start_key, end_key, limit, cursor } = options ?? {};
+    const afterKey = cursor ?? start_key;
+    const filtered = allKeys.filter((key) => {
+      if (afterKey && compareKeys(key, afterKey) <= 0) {
+        return false;
+      }
+      if (end_key && compareKeys(key, end_key) > 0) {
+        return false;
+      }
+      return true;
+    });
+    const slice = typeof limit === 'number' ? filtered.slice(0, limit) : filtered;
+    const records = slice.map((key) => this.items.get(key)!).filter(Boolean);
+    return {
+      items: records,
+      isTruncated: Boolean(limit && filtered.length > limit),
+      cursor:
+        limit && filtered.length > limit
+          ? records[records.length - 1]?.key
+          : records.length > 0
+          ? records[records.length - 1]?.key
+          : afterKey,
+    };
+  }
+
+  async delete(key: string): Promise<void> {
+    const record = this.items.get(key);
+    if (!record) {
+      return;
+    }
+    const now = new Date();
+    const retention = new Date(record.retention_until);
+    if (now < retention || record.legal_hold) {
+      throw new RetentionViolationError('Object is immutable during retention/legal hold');
+    }
+    this.items.delete(key);
+  }
+
+  reset(): void {
+    this.items.clear();
+  }
+}
+
+export interface R2AuditStoreConfig {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+  prefix?: string;
+}
+
+interface SignedRequestOptions {
+  method: string;
+  path: string;
+  query?: Record<string, string | undefined>;
+  headers?: Record<string, string>;
+  body?: string | Buffer;
+}
+
+function hash(input: string | Buffer): string {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+function hmac(key: Buffer, data: string): Buffer {
+  return crypto.createHmac('sha256', key).update(data).digest();
+}
+
+function formatAmzDate(date: Date): { amzDate: string; shortDate: string } {
+  const shortDate = date.toISOString().slice(0, 10).replace(/-/g, '');
+  const amzDate = `${shortDate}${date.toISOString().slice(11, 19).replace(/:/g, '')}Z`;
+  return { amzDate, shortDate };
+}
+
+function createCanonicalQuery(query?: Record<string, string | undefined>): string {
+  if (!query) return '';
+  const parts: string[] = [];
+  const keys = Object.keys(query).filter((key) => query[key] !== undefined);
+  keys.sort();
+  for (const key of keys) {
+    const value = query[key];
+    if (value === undefined) continue;
+    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
+  }
+  return parts.join('&');
+}
+
+function createCanonicalHeaders(headers: Record<string, string>): {
+  headerString: string;
+  signedHeaders: string;
+} {
+  const lowerEntries = Object.entries(headers)
+    .map(([key, value]) => [key.toLowerCase(), value.trim().replace(/\s+/g, ' ')] as const)
+    .sort(([a], [b]) => compareKeys(a, b));
+  const headerString = lowerEntries.map(([key, value]) => `${key}:${value}\n`).join('');
+  const signedHeaders = lowerEntries.map(([key]) => key).join(';');
+  return { headerString, signedHeaders };
+}
+
+function signRequest(config: R2AuditStoreConfig, options: SignedRequestOptions): {
+  url: string;
+  headers: Record<string, string>;
+} {
+  const region = 'auto';
+  const service = 's3';
+  const now = new Date();
+  const { amzDate, shortDate } = formatAmzDate(now);
+  const host = `${config.accountId}.r2.cloudflarestorage.com`;
+  const canonicalUri = options.path.startsWith('/') ? options.path : `/${options.path}`;
+  const canonicalQuery = createCanonicalQuery(options.query);
+  const body = options.body ?? '';
+  const payloadHash = hash(typeof body === 'string' ? body : body);
+  const baseHeaders: Record<string, string> = {
+    host,
+    'x-amz-content-sha256': payloadHash,
+    'x-amz-date': amzDate,
+    ...(options.headers ?? {}),
+  };
+  const { headerString, signedHeaders } = createCanonicalHeaders(baseHeaders);
+  const canonicalRequest = [
+    options.method,
+    canonicalUri,
+    canonicalQuery,
+    headerString,
+    '',
+    signedHeaders,
+    payloadHash,
+  ].join('\n');
+  const scope = `${shortDate}/${region}/${service}/aws4_request`;
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    scope,
+    hash(canonicalRequest),
+  ].join('\n');
+  const kDate = hmac(Buffer.from(`AWS4${config.secretAccessKey}`), shortDate);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, service);
+  const kSigning = hmac(kService, 'aws4_request');
+  const signature = crypto.createHmac('sha256', kSigning).update(stringToSign).digest('hex');
+  const authorization = `AWS4-HMAC-SHA256 Credential=${config.accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+  const signedHeadersWithAuth = { ...baseHeaders, Authorization: authorization };
+  const protocol = 'https://';
+  const querySuffix = canonicalQuery ? `?${canonicalQuery}` : '';
+  const url = `${protocol}${host}${canonicalUri}${querySuffix}`;
+  return { url, headers: signedHeadersWithAuth };
+}
+
+export class R2AuditStore implements AuditStore {
+  constructor(private config: R2AuditStoreConfig) {}
+
+  private prefixed(key: string): string {
+    const prefix = this.config.prefix?.replace(/\/+$/, '') ?? '';
+    if (!prefix) return key;
+    return `${prefix}/${key}`;
+  }
+
+  async append(record: AuditRecord): Promise<void> {
+    const path = `/${this.config.bucket}/${this.prefixed(record.key)}`;
+    const body = JSON.stringify(record.entry);
+    const request = signRequest(this.config, {
+      method: 'PUT',
+      path,
+      headers: {
+        'content-type': 'application/json',
+        'x-amz-object-lock-mode': 'COMPLIANCE',
+        'x-amz-object-lock-retain-until-date': record.retention_until,
+        ...(record.legal_hold ? { 'x-amz-object-lock-legal-hold': 'ON' } : {}),
+      },
+      body,
+    });
+    const response = await fetch(request.url, {
+      method: 'PUT',
+      headers: request.headers,
+      body,
+    });
+    if (!response.ok && response.status !== 200) {
+      if (response.status === 409) {
+        throw new ConflictError(`Object ${record.key} already exists`);
+      }
+      const text = await response.text();
+      throw new Error(`R2 putObject failed: ${response.status} ${text}`);
+    }
+  }
+
+  async get(key: string): Promise<AuditRecord | null> {
+    const path = `/${this.config.bucket}/${this.prefixed(key)}`;
+    const request = signRequest(this.config, {
+      method: 'GET',
+      path,
+    });
+    const response = await fetch(request.url, { method: 'GET', headers: request.headers });
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`R2 getObject failed: ${response.status} ${text}`);
+    }
+    const bodyText = await response.text();
+    const entry = JSON.parse(bodyText);
+    const retentionUntil = response.headers.get('x-amz-object-lock-retain-until-date');
+    const legalHold = response.headers.get('x-amz-object-lock-legal-hold');
+    const lastModified = response.headers.get('last-modified') ?? new Date().toISOString();
+    return {
+      key,
+      entry,
+      retention_until: retentionUntil ?? entry.worm?.retention_until ?? new Date(Date.now()).toISOString(),
+      legal_hold: legalHold === 'ON',
+      created_at: lastModified,
+    };
+  }
+
+  async list(options?: ListOptions): Promise<AuditStoreListResult> {
+    const query: Record<string, string> = { 'list-type': '2' };
+    const startAfterKey = options?.start_key;
+    if (startAfterKey) {
+      query.startafter = this.prefixed(startAfterKey);
+    }
+    if (options?.cursor) {
+      query['continuation-token'] = options.cursor;
+    }
+    if (options?.limit) {
+      query['max-keys'] = String(options.limit);
+    }
+    if (this.config.prefix) {
+      query.prefix = this.config.prefix.replace(/\/+$/, '') + '/';
+    }
+    const path = `/${this.config.bucket}`;
+    const request = signRequest(this.config, {
+      method: 'GET',
+      path,
+      query,
+    });
+    const response = await fetch(request.url, { method: 'GET', headers: request.headers });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`R2 listObjects failed: ${response.status} ${text}`);
+    }
+    const xml = await response.text();
+    const items: AuditRecord[] = [];
+    const contentMatches = xml.match(/<Contents>[\s\S]*?<\/Contents>/g) ?? [];
+    for (const content of contentMatches) {
+      const keyMatch = content.match(/<Key>(.*?)<\/Key>/);
+      if (!keyMatch) continue;
+      const key = keyMatch[1];
+      if (this.config.prefix && !key.startsWith(this.config.prefix)) {
+        continue;
+      }
+      const unprefixed = this.config.prefix ? key.substring(this.config.prefix.length + 1) : key;
+      const item = await this.get(unprefixed);
+      if (item) {
+        if (options?.end_key && compareKeys(unprefixed, options.end_key) > 0) {
+          break;
+        }
+        items.push(item);
+      }
+    }
+    const isTruncated = /<IsTruncated>true<\/IsTruncated>/.test(xml);
+    return {
+      items,
+      isTruncated,
+      cursor: (() => {
+        const match = xml.match(/<NextContinuationToken>(.*?)<\/NextContinuationToken>/);
+        if (match) {
+          return decodeURIComponent(match[1]);
+        }
+        if (items.length > 0) {
+          return items[items.length - 1]?.key;
+        }
+        return options?.cursor ?? startAfterKey;
+      })(),
+    };
+  }
+
+  async delete(key: string): Promise<void> {
+    const path = `/${this.config.bucket}/${this.prefixed(key)}`;
+    const request = signRequest(this.config, {
+      method: 'DELETE',
+      path,
+    });
+    const response = await fetch(request.url, { method: 'DELETE', headers: request.headers });
+    if (response.status === 404) {
+      return;
+    }
+    if (response.status === 409 || response.status === 403) {
+      throw new RetentionViolationError('Object locked by retention policy');
+    }
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`R2 deleteObject failed: ${response.status} ${text}`);
+    }
+  }
+}

--- a/app/api/audit/_lib/types.ts
+++ b/app/api/audit/_lib/types.ts
@@ -1,0 +1,108 @@
+export interface SafeCopyChecksum {
+  algorithm: 'sha256' | 'crc32c' | 'crc64nvme' | 'sha1';
+  value: string;
+}
+
+export interface SafeCopyMetadata {
+  bucket: string;
+  key: string;
+  etag: string;
+  checksum: SafeCopyChecksum;
+  expires_at?: string;
+}
+
+export interface WormMetadata {
+  retention_until: string;
+  legal_hold?: boolean;
+}
+
+export interface AuditLogInput {
+  ts_iso: string;
+  session_id: string;
+  actor: string;
+  url_sha256: string;
+  result: 'allowed' | 'blocked' | 'safe_copied';
+  safe_copy: SafeCopyMetadata;
+  client_ip?: string;
+  asn?: number;
+  mime_detected?: string;
+  size_bytes?: number;
+  reason?: string | null;
+  agent_version?: string;
+  dpi?: number;
+  pages?: number;
+  duration_ms?: number;
+  worm?: Partial<WormMetadata>;
+  version?: 1;
+}
+
+export interface AuditLogSignature {
+  prev_hash: string | null;
+  hmac: string;
+}
+
+export interface AuditLogStored extends AuditLogInput {
+  sig: AuditLogSignature;
+  version: 1;
+}
+
+export interface AuditRecord {
+  key: string;
+  entry: AuditLogStored;
+  retention_until: string;
+  legal_hold: boolean;
+  created_at: string;
+}
+
+export interface AppendResult {
+  key: string;
+  retention_until: string;
+  entry: AuditLogStored;
+}
+
+export interface VerifyRange {
+  start_key?: string;
+  end_key?: string;
+  limit?: number;
+}
+
+export interface ChainDiff {
+  key: string;
+  reason: 'missing-prev' | 'hash-mismatch' | 'hmac-mismatch';
+  expected?: string | null;
+  actual?: string | null;
+}
+
+export interface VerifyResult {
+  valid: boolean;
+  checked: number;
+  range_start?: string;
+  range_end?: string;
+  diffs: ChainDiff[];
+}
+
+export interface AuditServiceConfig {
+  retentionDays: number;
+  chainSecret: string;
+  legalHoldDefault?: boolean;
+}
+
+export interface ListOptions {
+  start_key?: string;
+  end_key?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface AuditStoreListResult {
+  items: AuditRecord[];
+  isTruncated: boolean;
+  cursor?: string;
+}
+
+export interface AuditStore {
+  append(record: AuditRecord): Promise<void>;
+  get(key: string): Promise<AuditRecord | null>;
+  list(options?: ListOptions): Promise<AuditStoreListResult>;
+  delete(key: string): Promise<void>;
+}

--- a/app/api/audit/route.ts
+++ b/app/api/audit/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createAuditServiceFromEnv } from './_lib/service';
+import { ValidationError } from './_lib/errors';
+
+function authorize(request: NextRequest, token: string | undefined, scope: string) {
+  if (!token) {
+    return NextResponse.json(
+      { error: 'authorization_not_configured', detail: `${scope} token is not configured` },
+      { status: 500 },
+    );
+  }
+  const header = request.headers.get('authorization');
+  if (!header || !header.startsWith('Bearer ')) {
+    return NextResponse.json(
+      { error: 'unauthorized', detail: `${scope} token missing` },
+      { status: 401 },
+    );
+  }
+  const provided = header.slice('Bearer '.length).trim();
+  if (provided !== token) {
+    return NextResponse.json(
+      { error: 'unauthorized', detail: `${scope} token invalid` },
+      { status: 401 },
+    );
+  }
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  const auth = authorize(request, process.env.AUDIT_WRITE_TOKEN, 'write');
+  if (auth) return auth;
+  const service = createAuditServiceFromEnv();
+  try {
+    const payload = await request.json();
+    const result = await service.append(payload);
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: 'invalid_request', detail: error.message }, { status: error.status ?? 400 });
+    }
+    console.error('audit append error', error);
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const auth = authorize(request, process.env.AUDIT_READ_TOKEN, 'read');
+  if (auth) return auth;
+  const service = createAuditServiceFromEnv();
+  const url = new URL(request.url);
+  const limitParam = url.searchParams.get('limit');
+  const startKey = url.searchParams.get('start_key') ?? undefined;
+  const endKey = url.searchParams.get('end_key') ?? undefined;
+  const cursorParam = url.searchParams.get('cursor') ?? undefined;
+  let limit: number | undefined;
+  if (limitParam !== null) {
+    limit = Number(limitParam);
+    if (!Number.isFinite(limit) || limit <= 0 || limit > 1000) {
+      return NextResponse.json(
+        { error: 'invalid_request', detail: 'limit must be between 1 and 1000' },
+        { status: 400 },
+      );
+    }
+  }
+  try {
+    const { items, cursor, isTruncated } = await service.list({
+      start_key: startKey ?? undefined,
+      end_key: endKey ?? undefined,
+      limit,
+      cursor: cursorParam,
+    });
+    return NextResponse.json({ items, cursor, is_truncated: isTruncated });
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: 'invalid_request', detail: error.message }, { status: error.status ?? 400 });
+    }
+    console.error('audit list error', error);
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+}

--- a/app/api/audit/verify/route.ts
+++ b/app/api/audit/verify/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createAuditServiceFromEnv } from '../_lib/service';
+import { ValidationError } from '../_lib/errors';
+
+function authorize(request: NextRequest, token: string | undefined) {
+  if (!token) {
+    return NextResponse.json(
+      { error: 'authorization_not_configured', detail: 'read token is not configured' },
+      { status: 500 },
+    );
+  }
+  const header = request.headers.get('authorization');
+  if (!header || !header.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'unauthorized', detail: 'read token missing' }, { status: 401 });
+  }
+  const provided = header.slice('Bearer '.length).trim();
+  if (provided !== token) {
+    return NextResponse.json({ error: 'unauthorized', detail: 'read token invalid' }, { status: 401 });
+  }
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  const auth = authorize(request, process.env.AUDIT_READ_TOKEN);
+  if (auth) return auth;
+  const service = createAuditServiceFromEnv();
+  try {
+    const payload = await request.json();
+    const limit = payload?.limit;
+    if (limit !== undefined) {
+      if (!Number.isFinite(limit) || limit <= 0 || limit > 5000) {
+        return NextResponse.json(
+          { error: 'invalid_request', detail: 'limit must be between 1 and 5000' },
+          { status: 400 },
+        );
+      }
+    }
+    const result = await service.verify({
+      start_key: payload?.start_key,
+      end_key: payload?.end_key,
+      limit,
+    });
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: 'invalid_request', detail: error.message }, { status: error.status ?? 400 });
+    }
+    console.error('audit verify error', error);
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "tsc -p tsconfig.tests.json && node --test dist-tests/tests/audit-service.test.js"
   },
   "dependencies": {
     "@zip.js/zip.js": "^2.7.34",

--- a/tests/audit-service.test.ts
+++ b/tests/audit-service.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import crypto from 'node:crypto';
+import { POST as appendPost, GET as listGet } from '../app/api/audit/route';
+import { DELETE as deleteHandler } from '../app/api/audit/[...key]/route';
+import { POST as verifyPost } from '../app/api/audit/verify/route';
+import { resetInMemoryAuditStore } from '../app/api/audit/_lib/service';
+
+function setupEnv() {
+  process.env.AUDIT_STORE = 'memory';
+  process.env.AUDIT_CHAIN_SECRET = 'test-secret-key';
+  process.env.AUDIT_RETENTION_DAYS = '90';
+  process.env.AUDIT_WRITE_TOKEN = 'write-token';
+  process.env.AUDIT_READ_TOKEN = 'read-token';
+}
+
+function makeAuditPayload(overrides: Partial<Record<string, unknown>> = {}) {
+  const ts = new Date();
+  return {
+    ts_iso: ts.toISOString(),
+    session_id: crypto.randomUUID(),
+    actor: 'auditor@example.com',
+    url_sha256: 'a'.repeat(64),
+    result: 'safe_copied',
+    safe_copy: {
+      bucket: 'demo-bucket',
+      key: `logs/${crypto.randomUUID()}.json`,
+      etag: '"etag-value"',
+      checksum: {
+        algorithm: 'sha256',
+        value: 'deadbeef'.padEnd(64, '0'),
+      },
+      expires_at: new Date(ts.getTime() + 3600 * 1000).toISOString(),
+    },
+    agent_version: 'audit-agent/1.0.0',
+    ...overrides,
+  };
+}
+
+test.beforeEach(() => {
+  setupEnv();
+  resetInMemoryAuditStore();
+});
+
+test('append endpoint stores immutable audit log', async () => {
+  const payload = makeAuditPayload();
+  const request = new Request('http://localhost/api/audit', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Bearer write-token',
+    },
+    body: JSON.stringify(payload),
+  });
+  const response = await appendPost(request as any);
+  assert.equal(response.status, 201);
+  const body = await response.json();
+  assert.ok(body.key);
+  assert.equal(body.entry.safe_copy.etag, payload.safe_copy.etag);
+  assert.equal(body.entry.sig.prev_hash, null);
+
+  const listRequest = new Request('http://localhost/api/audit?limit=10', {
+    headers: { authorization: 'Bearer read-token' },
+  });
+  const listResponse = await listGet(listRequest as any);
+  assert.equal(listResponse.status, 200);
+  const listBody = await listResponse.json();
+  assert.equal(listBody.items.length, 1);
+  assert.equal(listBody.items[0].entry.safe_copy.key, payload.safe_copy.key);
+});
+
+test('delete during retention returns 409 conflict', async () => {
+  const payload = makeAuditPayload();
+  const createRequest = new Request('http://localhost/api/audit', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Bearer write-token',
+    },
+    body: JSON.stringify(payload),
+  });
+  const createResponse = await appendPost(createRequest as any);
+  const created = await createResponse.json();
+  const keySegments = (created.key as string).split('/');
+
+  const deleteRequest = new Request(`http://localhost/api/audit/${created.key}`, {
+    method: 'DELETE',
+    headers: { authorization: 'Bearer write-token' },
+  });
+  const deleteResponse = await deleteHandler(deleteRequest as any, { params: { key: keySegments } });
+  assert.equal(deleteResponse.status, 409);
+  const deleteBody = await deleteResponse.json();
+  assert.equal(deleteBody.error, 'retention_active');
+});
+
+test('chain verification succeeds from arbitrary start key', async () => {
+  const firstPayload = makeAuditPayload();
+  const secondPayload = makeAuditPayload({
+    ts_iso: new Date(Date.now() + 1000).toISOString(),
+    session_id: crypto.randomUUID(),
+    url_sha256: 'b'.repeat(64),
+  });
+
+  const firstRequest = new Request('http://localhost/api/audit', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Bearer write-token',
+    },
+    body: JSON.stringify(firstPayload),
+  });
+  const firstResponse = await appendPost(firstRequest as any);
+  const firstBody = await firstResponse.json();
+
+  const secondRequest = new Request('http://localhost/api/audit', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Bearer write-token',
+    },
+    body: JSON.stringify(secondPayload),
+  });
+  await appendPost(secondRequest as any);
+
+  const verifyRequest = new Request('http://localhost/api/audit/verify', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Bearer read-token',
+    },
+    body: JSON.stringify({ start_key: firstBody.key }),
+  });
+  const verifyResponse = await verifyPost(verifyRequest as any);
+  assert.equal(verifyResponse.status, 200);
+  const verifyBody = await verifyResponse.json();
+  assert.equal(verifyBody.valid, true);
+  assert.ok(verifyBody.checked >= 1);
+  assert.equal(verifyBody.diffs.length, 0);
+});

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-tests",
+    "module": "commonjs",
+    "target": "es2019",
+    "noEmit": false,
+    "moduleResolution": "node",
+    "allowJs": false,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "tests/**/*.ts",
+    "app/api/audit/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- implement audit service abstractions with signature chaining, retention policy handling, and Cloudflare R2 SigV4 support
- add authenticated API routes for append-only writes, immutable object deletion checks, and chain verification endpoints
- cover append, retention conflict, and range verification behaviour with node:test along with a TypeScript test build configuration

## Testing
- `npm run test`
- `npm run lint` *(fails: missing optional @typescript-eslint plugin in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d372381b9c8322b72ebbf3cdb38076